### PR TITLE
return True (don't raise) for collectonly

### DIFF
--- a/pytest_mp/plugin.py
+++ b/pytest_mp/plugin.py
@@ -295,7 +295,7 @@ def pytest_runtestloop(session):
         raise session.Interrupted("{} errors during collection".format(session.testsfailed))
 
     if session.config.option.collectonly:
-        raise True
+        return True
 
     use_mp, num_processes = load_mp_options(session)
 


### PR DESCRIPTION
Running `py.test --collectonly` results in a traceback due to `pytest-mp` using `raise True` instead of `return True` in `pytest_runtestloop`.

Sample failure:
https://gist.github.com/jladdjr/9947255bb9567842b84e1b1246203029#file-pytest_collect-L31