### PR TITLE
Get closest mp_group marker

### DIFF
--- a/pytest_mp/plugin.py
+++ b/pytest_mp/plugin.py
@@ -112,7 +112,7 @@ def load_mp_options(session):
 
 
 def get_item_batch_name_and_strategy(item):
-    marker = item.get_marker('mp_group')
+    marker = item.get_closest_marker('mp_group')
     if marker is None:
         return None, None
 


### PR DESCRIPTION
This allows nested `mp_group` marker, only the closest marker will be used. For example:
```
@pytest.mark.mp_group('Test_MP_Marker', 'serial')
class Test_MP_Marker:
    def test_serial_1(self):
        pass
    def test_serial_2(self):
        pass
    @pytest.mark.mp_group('test_isolated_serial', 'isolated_serial')
    def test_isolated_serial(self):
        pass
```
`test_serial_1` and `test_serial_1` will be executed in serial. But `test_isolated_serial` will be executed in isolated_serial.