### PR TITLE
Run serial groups ahead of free groups

### DIFF
--- a/pytest_mp/plugin.py
+++ b/pytest_mp/plugin.py
@@ -249,9 +249,9 @@ def wait_until_can_submit(num_processes):
 
 
 def run_batched_tests(batches, session, num_processes):
-    sorting = dict(free=2, serial=2, isolated_free=1, isolated_serial=0)
+    sorting = dict(free=3, serial=2, isolated_free=1, isolated_serial=0)
 
-    batch_names = sorted(batches.keys(), key=lambda x: sorting.get(batches[x]['strategy'], 3))
+    batch_names = sorted(batches.keys(), key=lambda x: sorting.get(batches[x]['strategy'], 4))
 
     if not num_processes:
         for i, batch in enumerate(batch_names):


### PR DESCRIPTION
In the original design, serial groups are expected to run with free groups in parallel. However, in practical, serial groups always run behind of free groups. The reason is that usually there is only one free group called [ungrouped](https://github.com/ansible/pytest-mp/blob/f74119222113cec78a5142269ebe27d7301dbd2b/pytest_mp/plugin.py#L151), and that group usually comes first since groups are stored in an [OrderedDict](https://github.com/ansible/pytest-mp/blob/f74119222113cec78a5142269ebe27d7301dbd2b/pytest_mp/plugin.py#L146)

Running serial groups after free groups causes two problems. 

First, there could be a dominant group that takes a much longer time than all other groups. Thus at the end of the test, it is possible that only the dominant group is still running and only one process is working. If we run the serial groups before free groups, the dominant group could run with the free groups in parallel.

Second, tests in serial groups are usually more fragile, and they could be affected by the noise introduced in former tests. There would be less noise if we run them before free groups.