### PR TITLE
Fix hookspec userwarning and multi marks checker

### DIFF
--- a/pytest_mp/junitxml.py
+++ b/pytest_mp/junitxml.py
@@ -51,8 +51,8 @@ class MPLogXML(LogXML):
         suite_stop_time = time.time()
         suite_time_delta = suite_stop_time - self.suite_start_time
 
-        numtests = (self.stats['passed'] + self.stats['failure'] +
-                    self.stats['skipped'] + self.stats['error'] -
+        numtests = (self.stats['passed'] + self.stats['failure'] +  # noqa W504
+                    self.stats['skipped'] + self.stats['error'] -  # noqa W504
                     self.cnt_double_fail_tests)
         logfile.write('<?xml version="1.0" encoding="utf-8"?>')
 

--- a/pytest_mp/plugin.py
+++ b/pytest_mp/plugin.py
@@ -112,6 +112,11 @@ def load_mp_options(session):
 
 
 def get_item_batch_name_and_strategy(item):
+    # First check if there is more than one mark for mp_group
+    markers = [mark for mark in item.iter_markers() if mark.name == 'mp_group']
+    if len(markers) > 1:
+        raise Exception('Detected too many mp_group values for {}'.format(item.name))
+
     marker = item.get_closest_marker('mp_group')
     if marker is None:
         return None, None

--- a/pytest_mp/terminal.py
+++ b/pytest_mp/terminal.py
@@ -42,7 +42,8 @@ class MPTerminalReporter(TerminalReporter):
 
     def pytest_runtest_logreport(self, report):
         rep = report
-        res = self.config.hook.pytest_report_teststatus(report=rep)
+        # following example here https://github.com/pytest-dev/pytest/blob/03ef54670662def8422ec983969b81250d543433/src/_pytest/terminal.py#L387
+        res = self.config.hook.pytest_report_teststatus(report=rep, config=self.config)
         cat, letter, word = res
 
         # This helps make TerminalReporter process-safe.

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -8,24 +8,24 @@ def test_group_info_marker_kwargs_from_args(testdir, use_mp):
 
         @pytest.mark.mp_group('One')
         def test_one(request):
-            kwargs = request.node.get_marker('mp_group_info').kwargs
+            kwargs = request.node.get_closest_marker('mp_group_info').kwargs
             assert kwargs['group'] == 'One'
             assert kwargs['strategy'] == 'free'
 
         @pytest.mark.mp_group('One')
         def test_two(request):
-            kwargs = request.node.get_marker('mp_group_info').kwargs
+            kwargs = request.node.get_closest_marker('mp_group_info').kwargs
             assert kwargs['group'] == 'One'
             assert kwargs['strategy'] == 'free'
 
         @pytest.mark.mp_group('Two', 'serial')
         def test_three(request):
-            kwargs = request.node.get_marker('mp_group_info').kwargs
+            kwargs = request.node.get_closest_marker('mp_group_info').kwargs
             assert kwargs['group'] == 'Two'
             assert kwargs['strategy'] == 'serial'
 
         def test_four(request):
-            kwargs = request.node.get_marker('mp_group_info').kwargs
+            kwargs = request.node.get_closest_marker('mp_group_info').kwargs
             assert kwargs['group'] == 'ungrouped'
             assert kwargs['strategy'] == 'free'
 
@@ -43,24 +43,24 @@ def test_group_info_marker_kwargs_from_kwargs(testdir, use_mp):
 
         @pytest.mark.mp_group(group='One')
         def test_one(request):
-            kwargs = request.node.get_marker('mp_group_info').kwargs
+            kwargs = request.node.get_closest_marker('mp_group_info').kwargs
             assert kwargs['group'] == 'One'
             assert kwargs['strategy'] == 'free'
 
         @pytest.mark.mp_group(group='One')
         def test_two(request):
-            kwargs = request.node.get_marker('mp_group_info').kwargs
+            kwargs = request.node.get_closest_marker('mp_group_info').kwargs
             assert kwargs['group'] == 'One'
             assert kwargs['strategy'] == 'free'
 
         @pytest.mark.mp_group(group='Two', strategy='serial')
         def test_three(request):
-            kwargs = request.node.get_marker('mp_group_info').kwargs
+            kwargs = request.node.get_closest_marker('mp_group_info').kwargs
             assert kwargs['group'] == 'Two'
             assert kwargs['strategy'] == 'serial'
 
         def test_four(request):
-            kwargs = request.node.get_marker('mp_group_info').kwargs
+            kwargs = request.node.get_closest_marker('mp_group_info').kwargs
             assert kwargs['group'] == 'ungrouped'
             assert kwargs['strategy'] == 'free'
 
@@ -78,18 +78,18 @@ def test_group_info_marker_kwargs_from_args_and_kwargs(testdir, use_mp):
 
         @pytest.mark.mp_group('One', strategy='serial')
         def test_one(request):
-            kwargs = request.node.get_marker('mp_group_info').kwargs
+            kwargs = request.node.get_closest_marker('mp_group_info').kwargs
             assert kwargs['group'] == 'One'
             assert kwargs['strategy'] == 'serial'
 
         @pytest.mark.mp_group(group='One')
         def test_two(request):
-            kwargs = request.node.get_marker('mp_group_info').kwargs
+            kwargs = request.node.get_closest_marker('mp_group_info').kwargs
             assert kwargs['group'] == 'One'
             assert kwargs['strategy'] == 'serial'  # inherited
 
         def test_three(request):
-            kwargs = request.node.get_marker('mp_group_info').kwargs
+            kwargs = request.node.get_closest_marker('mp_group_info').kwargs
             assert kwargs['group'] == 'ungrouped'
             assert kwargs['strategy'] == 'free'
 

--- a/tests/test_invocation.py
+++ b/tests/test_invocation.py
@@ -46,8 +46,7 @@ def test_ini_without_cmdline(testdir, ini_content, mp, num_processes):
     """.format(mp, num_processes))
 
     result = testdir.runpytest()
-
-    result.stdout.fnmatch_lines(['*= 2 passed in * seconds =*'])
+    result.stdout.re_match_lines(['.*2 passed.*in.*seconds.*'])
     assert result.ret == 0
 
 
@@ -88,5 +87,5 @@ def test_ini_with_cmdline(testdir, cmd_mp, cmd_num_processes, ini_content, ini_m
 
     result = testdir.runpytest(*cmd_options)
 
-    result.stdout.fnmatch_lines(['*= 2 passed in * seconds =*'])
+    result.stdout.re_match_lines(['.*2 passed.*in.*seconds.*'])
     assert result.ret == 0

--- a/tests/test_separation.py
+++ b/tests/test_separation.py
@@ -13,7 +13,7 @@ def test_isolated_trail_separation(testdir):
 
         @contextmanager
         def _trail_fixture(num, mp_trail, request):
-            group = request.node.get_marker('mp_group').kwargs['group']
+            group = request.node.get_closest_marker('mp_group').kwargs['group']
             group += num
             with mp_trail(num) as start:
                 if start:


### PR DESCRIPTION
Fix bug introduced by update to use get_closest marker that messed up finding multiple mp_groups

Update tests to use new pytest 4.0+ safe get_closest_marker

Update call to self.config.hook.pytest_report_teststatus to pass all expected args