### PR TITLE
Silence pytest warning

### DIFF
--- a/pytest_mp/plugin.py
+++ b/pytest_mp/plugin.py
@@ -381,6 +381,8 @@ def pytest_configure(config):
                             "mp_group('GroupName', strategy): test (suite) is in named "
                             "grouped w/ desired strategy: 'free' (default), 'serial', "
                             "'isolated_free', or 'isolated_serial'.")
+    config.addinivalue_line('markers',
+                            "mp_group_info: internal use only")
 
     standard_reporter = config.pluginmanager.get_plugin('terminalreporter')
     if standard_reporter:


### PR DESCRIPTION
Without this change, I get the following warning when running pytest 5.3.5:

```
PytestUnknownMarkWarning: Unknown pytest.mark.mp_group_info - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
  PytestUnknownMarkWarning,
```